### PR TITLE
Updating element_sample for scipy compatibility

### DIFF
--- a/PyFVCOM/grid/_grid.py
+++ b/PyFVCOM/grid/_grid.py
@@ -4064,7 +4064,7 @@ def element_sample(xc, yc, positions):
 
     # Create a set for edges that are indices of the points.
     edges = []
-    for vertex in triangulation.vertices:
+    for vertex in triangulation.simplices:
         # For each edge of the triangle, sort the vertices (sorting avoids duplicated edges being added to the set)
         # and add to the edges set.
         edge = sorted([vertex[0], vertex[1]])


### PR DESCRIPTION
Fixing the  horizontal_transect_elements/element_sample function as uses outdated vertices call to Delaunay object instead of simplices from scipy.spatial.Delaunay